### PR TITLE
Uncomment jack_set_port_rename_callback() since it seems to work

### DIFF
--- a/src/client/callbacks.rs
+++ b/src/client/callbacks.rs
@@ -343,7 +343,6 @@ where
     /// # TODO
     ///
     /// * Handled failed registrations
-    /// * Fix `jack_set_port_rename_callback`
     ///
     /// # Unsafe
     ///
@@ -367,8 +366,7 @@ where
             data_ptr,
         );
         j::jack_set_port_registration_callback(client, Some(port_registration::<N, P>), data_ptr);
-        // doesn't compile for testing since it is a weak export
-        // j::jack_set_port_rename_callback(client, Some(port_rename::<N, P), data_ptr);
+        j::jack_set_port_rename_callback(client, Some(port_rename::<N, P>), data_ptr);
         j::jack_set_port_connect_callback(client, Some(port_connect::<N, P>), data_ptr);
         j::jack_set_graph_order_callback(client, Some(graph_order::<N, P>), data_ptr);
         j::jack_set_xrun_callback(client, Some(xrun::<N, P>), data_ptr);


### PR DESCRIPTION
Comment suggested "doesn't compile for testing since it is a weak export" but I was able to compile and run tests just fine. I have Linux / Devuan with jack2 (not pipewire).

A few tests were failing, but commenting or uncommenting the code did not affect the outcome.

I changed this since I maintain a program to automatically update connections based on which (jack) clients and ports are present and I noticed Ardour seems to rename ports.. and I would prefer to not having to request a full list of ports and connections on every event..

Also, thanks for your great lib!